### PR TITLE
Update protos end of utterance params

### DIFF
--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -111,6 +111,15 @@ message StreamingRecognizeRequest {
   RequestId id = 100;
 }
 
+// Provides information on all end of utterance related values
+message EOUConfig {
+	optional int32 endpoint_start_history = 1;
+	optional float endpoint_start_threshold = 2;
+	optional int32 endpoint_reset_history = 3;
+	optional int32 endpoint_response_history = 4;
+	optional float endpoint_stop_threshold = 5;
+}
+
 // Provides information to the recognizer that specifies how to process the
 // request
 message RecognitionConfig {
@@ -190,11 +199,14 @@ message RecognitionConfig {
   // parameters. For non-streaming requests, the diarization results will be
   // provided only in the top alternative of the FINAL SpeechRecognitionResult.
   SpeakerDiarizationConfig diarization_config = 19;
+	
+  // End of Utterance values are configurable
+  EOUConfig eou_config = 24;	
 
   // Custom fields for passing request-level
   // configuration options to plugins used in the
   // model pipeline.
-  map<string, string> custom_configuration = 24;
+  map<string, string> custom_configuration = 29;
 }
 
 // Provides information to the recognizer that specifies how to process the

--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -112,14 +112,14 @@ message StreamingRecognizeRequest {
 }
 
 /*
- * EndpointingConfig is used for configure all end of utterance related values
+ * EndpointingConfig is used for configuring different fields related to start or end of utterance
  */
 message EndpointingConfig {
-	optional int32 start_history = 1;
-	optional float start_threshold = 2;
-	optional int32 stop_history = 3;
-	optional int32 stop_history_eou = 4;
-	optional float stop_threshold = 5;
+  optional int32 start_history = 1;
+  optional float start_threshold = 2;
+  optional int32 stop_history = 3;
+  optional int32 stop_history_eou = 4;
+  optional float stop_threshold = 5;
 }
 
 // Provides information to the recognizer that specifies how to process the
@@ -207,7 +207,7 @@ message RecognitionConfig {
   // model pipeline.
   map<string, string> custom_configuration = 24;
 
-  // Option to configure End of Utterance parameters.
+  // Option to configure different fields related to start or end of utterance.
   // If empty, Riva will use default values.
   EndpointingConfig endpointing_config = 25;	
 }

--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -112,9 +112,9 @@ message StreamingRecognizeRequest {
 }
 
 /*
- * EOUConfig is used for configure all end of utterance related values
+ * EndpointingConfig is used for configure all end of utterance related values
  */
-message EOUConfig {
+message EndpointingConfig {
 	optional int32 start_history = 1;
 	optional float start_threshold = 2;
 	optional int32 stop_history = 3;
@@ -209,7 +209,7 @@ message RecognitionConfig {
 
   // Option to configure End of Utterance parameters.
   // If empty, Riva will use default values.
-  EOUConfig eou_config = 25;	
+  EndpointingConfig endpointing_config = 25;	
 }
 
 // Provides information to the recognizer that specifies how to process the

--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -111,13 +111,15 @@ message StreamingRecognizeRequest {
   RequestId id = 100;
 }
 
-// Provides information on all end of utterance related values
+/*
+ * EOUConfig is used for configure all end of utterance related values
+ */
 message EOUConfig {
-	optional int32 endpoint_start_history = 1;
-	optional float endpoint_start_threshold = 2;
-	optional int32 endpoint_reset_history = 3;
-	optional int32 endpoint_response_history = 4;
-	optional float endpoint_stop_threshold = 5;
+	optional int32 start_history = 1;
+	optional float start_threshold = 2;
+	optional int32 stop_history = 3;
+	optional int32 stop_history_eou = 4;
+	optional float stop_threshold = 5;
 }
 
 // Provides information to the recognizer that specifies how to process the
@@ -199,14 +201,15 @@ message RecognitionConfig {
   // parameters. For non-streaming requests, the diarization results will be
   // provided only in the top alternative of the FINAL SpeechRecognitionResult.
   SpeakerDiarizationConfig diarization_config = 19;
-	
-  // End of Utterance values are configurable
-  EOUConfig eou_config = 24;	
 
   // Custom fields for passing request-level
   // configuration options to plugins used in the
   // model pipeline.
-  map<string, string> custom_configuration = 29;
+  map<string, string> custom_configuration = 24;
+
+  // Option to configure End of Utterance parameters.
+  // If empty, Riva will use default values.
+  EOUConfig eou_config = 25;	
 }
 
 // Provides information to the recognizer that specifies how to process the

--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -209,7 +209,7 @@ message RecognitionConfig {
 
   // Config for tuning start or end of utterance parameters.
   // If empty, Riva will use default values or custom values if specified in riva-build arguments.
-  EndpointingConfig endpointing_config = 25;	
+  optional EndpointingConfig endpointing_config = 25;	
 }
 
 // Provides information to the recognizer that specifies how to process the

--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -207,8 +207,8 @@ message RecognitionConfig {
   // model pipeline.
   map<string, string> custom_configuration = 24;
 
-  // Option to configure different fields related to start or end of utterance.
-  // If empty, Riva will use default values.
+  // Config for tuning start or end of utterance parameters.
+  // If empty, Riva will use default values or custom values if specified in riva-build arguments.
   EndpointingConfig endpointing_config = 25;	
 }
 


### PR DESCRIPTION
With these changes, clients can now configure end and start of utterance for streaming ASR client