### PR TITLE
custom_dnt_phrases field added to TranslateTextRequest

### DIFF
--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -137,11 +137,13 @@ message TranslateTextRequest {
   string model = 2;
   string source_language = 3;
   string target_language = 4;
-// A list of words or phrases that are not to be translated or
-// to be custom translated by the pipeline. Words to be custom translated
-// should be specified as "<word>##<custom_translation>" and
-// words not be translated should be specified as "<word>".
+
+  // A list of words or phrases that are not to be translated or
+  // to be custom translated by the pipeline. Words to be custom translated
+  // should be specified as "<word>##<custom_translation>" and
+  // words not be translated should be specified as "<word>".
   repeated string dnt_phrases = 5;
+
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.
   RequestId id = 100;

--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -137,7 +137,7 @@ message TranslateTextRequest {
   string model = 2;
   string source_language = 3;
   string target_language = 4;
-
+  repeated string dnt_phrases = 5;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.
   RequestId id = 100;

--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -137,7 +137,12 @@ message TranslateTextRequest {
   string model = 2;
   string source_language = 3;
   string target_language = 4;
-  repeated string custom_dnt_phrases = 5;
+  //This field contains list of words or phrases which are not to be translated 
+  //and also a list of words and phrases which are to be custom translated.
+  //The words which are be custom translated are present as "<original>##<translation>"
+  //the words which are not to be translated are present as "<word>".
+  //All these words and phrases are separted by commas in dnt_phrases_string.
+  repeated string dnt_phrases = 5;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.
   RequestId id = 100;

--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -137,7 +137,7 @@ message TranslateTextRequest {
   string model = 2;
   string source_language = 3;
   string target_language = 4;
-  repeated string dnt_phrases = 5;
+  repeated string custom_dnt_phrases = 5;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.
   RequestId id = 100;

--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -137,11 +137,10 @@ message TranslateTextRequest {
   string model = 2;
   string source_language = 3;
   string target_language = 4;
-  //This field contains list of words or phrases which are not to be translated 
-  //and also a list of words and phrases which are to be custom translated.
-  //The words which are be custom translated are present as "<original>##<translation>"
-  //the words which are not to be translated are present as "<word>".
-  //All these words and phrases are separted by commas in dnt_phrases_string.
+// A list of words or phrases that are not to be translated or
+// to be custom translated by the pipeline. Words to be custom translated
+// should be specified as "<word>##<custom_translation>" and
+// words not be translated should be specified as "<word>".
   repeated string dnt_phrases = 5;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.


### PR DESCRIPTION
The custom_dnt_phrases field has been added to the TranslateTextRequest message in the Riva NMT  service. This enhancement allows users to specify custom phrases and their translations and also the DNT (Do Not Translate) phrases for each translation request.