### PR TITLE
Max Length Variation

### DIFF
--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -144,7 +144,7 @@ message TranslateTextRequest {
   // words not be translated should be specified as "<word>##".
   repeated string dnt_phrases = 5;
 
-  //Max Length variation controls the allowed difference between source and translated text.
+  //controls the maximum variation between the length of source and translated text in terms of tokens.
   string max_len_variation = 6;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.

--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -144,7 +144,8 @@ message TranslateTextRequest {
   // words not be translated should be specified as "<word>##".
   repeated string dnt_phrases = 5;
 
-  string max_gen_length = 6;
+  //Max Length variation controls the allowed difference between source and translated text.
+  string max_len_variation = 6;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.
   RequestId id = 100;

--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -144,7 +144,7 @@ message TranslateTextRequest {
   // words not be translated should be specified as "<word>##".
   repeated string dnt_phrases = 5;
 
-  //controls the maximum variation between the length of source and translated text in terms of tokens.
+  // controls the maximum variation between the length of source and translated text in terms of tokens.
   string max_len_variation = 6;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.

--- a/riva/proto/riva_nmt.proto
+++ b/riva/proto/riva_nmt.proto
@@ -144,6 +144,7 @@ message TranslateTextRequest {
   // words not be translated should be specified as "<word>##".
   repeated string dnt_phrases = 5;
 
+  string max_gen_length = 6;
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding response.
   RequestId id = 100;


### PR DESCRIPTION
Max length variation is added to the TranslateTextRequest. This parameter controls the maximum allowed difference between source text and translated text.