### PR TITLE
feat: asr: add force_eou field to StreamingRecognizeRequest

### DIFF
--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -106,11 +106,14 @@ message StreamingRecognizeRequest {
     bytes audio_content = 2;
   }
 
-  // If true, forces an immediate end-of-utterance for the current stream,
-  // emitting a final transcript without ending the stream. Unlike closing the
-  // stream (is_last), the stream remains open and subsequent audio continues
-  // as a new utterance. Can be set on any audio_content message.
-  bool force_eou = 3;
+  // Per-chunk runtime configuration passed alongside audio_content messages.
+  // Supported keys:
+  //   "force_eou" = "true" : Forces an immediate end-of-utterance for the
+  //       current stream, emitting a final transcript without ending the stream.
+  //       Unlike closing the stream (is_last), the stream remains open and
+  //       subsequent audio continues as a new utterance. Only supported for
+  //       cache-aware RNNT models.
+  map<string, string> runtime_config = 3;
 
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding responses.

--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -107,12 +107,14 @@ message StreamingRecognizeRequest {
   }
 
   // Per-chunk runtime configuration passed alongside audio_content messages.
+  // This is an OPTIONAL parameter which should be used when client needs to 
+  // tune server configuration during an ongoing session.
   // Supported keys:
   //   "force_eou" = "true" : Forces an immediate end-of-utterance for the
-  //       current stream, emitting a final transcript without ending the stream.
-  //       Unlike closing the stream (is_last), the stream remains open and
-  //       subsequent audio continues as a new utterance. Only supported for
-  //       cache-aware RNNT models.
+  //   current stream, emitting a final transcript without ending the stream.
+  //   Unlike closing the stream (is_last), the stream remains open and
+  //   subsequent audio continues as a new utterance. Only supported for
+  //   cache-aware RNNT models.
   map<string, string> runtime_config = 3;
 
   // The ID to be associated with the request. If provided, this will be

--- a/riva/proto/riva_asr.proto
+++ b/riva/proto/riva_asr.proto
@@ -106,6 +106,12 @@ message StreamingRecognizeRequest {
     bytes audio_content = 2;
   }
 
+  // If true, forces an immediate end-of-utterance for the current stream,
+  // emitting a final transcript without ending the stream. Unlike closing the
+  // stream (is_last), the stream remains open and subsequent audio continues
+  // as a new utterance. Can be set on any audio_content message.
+  bool force_eou = 3;
+
   // The ID to be associated with the request. If provided, this will be
   // returned in the corresponding responses.
   RequestId id = 100;


### PR DESCRIPTION
Add bool force_eou = 3 outside the oneof so it can be sent alongside audio_content. When set, the server forces an immediate EOU for the current utterance without terminating the stream.